### PR TITLE
Change to mask password on the Surround SCM Config section

### DIFF
--- a/src/main/resources/hudson/scm/SurroundSCM/config.jelly
+++ b/src/main/resources/hudson/scm/SurroundSCM/config.jelly
@@ -22,7 +22,7 @@
       <f:textbox name="SurroundSCM.userName" value="${scm.userName}" />
     </f:entry>
     <f:entry title="Password">
-      <f:textbox name="SurroundSCM.password" value="${scm.password}" />
+      <f:password name="SurroundSCM.password" value="${scm.password}" />
     </f:entry>
    <f:entry title="Branch">
       <f:textbox name="SurroundSCM.branch" value="${scm.branch}" />


### PR DESCRIPTION
Changed the 'password' textbox from a simple textbox to a password textbox to mask passwords.
